### PR TITLE
Fix build and add a detect script to predict the next version number

### DIFF
--- a/.github/script/incrementVersion.sh
+++ b/.github/script/incrementVersion.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+LOGS=$(git log --oneline $(git describe --tags --abbrev=0 @^)..@)
+BREAKING_CHANGE=false
+
+for log in $LOGS
+do
+    echo "> [$log]"
+    if [ "$log" == ":boom:" ]; then
+      BREAKING_CHANGE=true;
+    fi
+done
+
+if [ "$BREAKING_CHANGE" == true ]; then
+  echo "BREAKING_CHANGE"
+  ./gradlew incrementMajor
+else
+  echo "NO BREAKING_CHANGE"
+  ./gradlew incrementMinor
+fi

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         java-version: 1.8
     - name: Increment version number
-      run: ./gradlew incrementMajor
+      run: ./.github/script/incrementVersion.sh
     - name: extract real version
       id: extract_version
       run: echo "::set-output name=v::$(cat version.properties | grep 'semver' | sed -e 's/^version.semver=//')"

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -21,8 +21,6 @@ jobs:
     - name: extract real version
       id: extract_version
       run: echo "::set-output name=v::$(cat version.properties | grep 'semver' | sed -e 's/^version.semver=//')"
-    - name: Build
-      run: ./gradlew build
     - name: Commit files
       run: |
         git config --local user.email "updatarium@saagie.com"
@@ -31,8 +29,6 @@ jobs:
         git commit -m ":bookmark: Bump new version ${{ steps.extract_version.outputs.v }}"
     - name: Build with Gradle
       run: ./gradlew build test
-    - name: Quality analysis
-      run: ./gradlew aggregateDetekt
     - name: Publish on bintray
       run: ./gradlew bintrayUpload -PbintrayUsername=${{ secrets.BINTRAY_USERNAME }} -PbintrayApiKey=${{ secrets.BINTRAY_APIKEY }}
     - name: Create Release


### PR DESCRIPTION
Remove the double build in master.
Add a script to detect with version number (major or minor) will be incremented (base on commit logs)

Increment major if `:boom:` is present, increment minor otherwise ... 

Simple rule for now.

It will close #45  and close #43  