### PR TITLE
Add a configuration to list files using traverse children

### DIFF
--- a/core/src/test/kotlin/io/saagie/updatarium/dsl/ChangeSetTest.kt
+++ b/core/src/test/kotlin/io/saagie/updatarium/dsl/ChangeSetTest.kt
@@ -42,7 +42,7 @@ class ChangeSetTest {
                 BasicAction { actionRecord.add("action4") }
             )
         )
-        val config = UpdatariumConfiguration(persistEngine = TestPersistEngine())
+        val config = UpdatariumConfiguration(persistEngine = TestPersistEngine(), listFilesRecursively = true)
         changeset.execute(config)
 
         assertThat(actionRecord)
@@ -66,7 +66,11 @@ class ChangeSetTest {
                 BasicAction { actionRecord.add("action4") }
             )
         )
-        val config = UpdatariumConfiguration(failfast = false,persistEngine = TestPersistEngine())
+        val config = UpdatariumConfiguration(
+            failfast = false,
+            persistEngine = TestPersistEngine(),
+            listFilesRecursively =true
+        )
         changeset.execute(config)
 
         assertThat(actionRecord)
@@ -120,7 +124,7 @@ class ChangeSetTest {
                 BasicAction { actionRecord.add("action4") }
             )
         )
-        val config = UpdatariumConfiguration(dryRun = true, persistEngine = TestPersistEngine())
+        val config = UpdatariumConfiguration(dryRun = true, persistEngine = TestPersistEngine(), listFilesRecursively =true)
         changeset.execute(config)
 
         assertThat(actionRecord).isEmpty()

--- a/core/src/test/kotlin/io/saagie/updatarium/dsl/ChangelogTest.kt
+++ b/core/src/test/kotlin/io/saagie/updatarium/dsl/ChangelogTest.kt
@@ -50,7 +50,7 @@ class ChangelogTest {
                 )
             }
 
-            val config = UpdatariumConfiguration(persistEngine = TestPersistEngine())
+            val config = UpdatariumConfiguration(persistEngine = TestPersistEngine(), listFilesRecursively = true)
             changelog.execute(config)
 
             assertThat((config.persistEngine as TestPersistEngine).changeSetTested).containsExactly(
@@ -87,7 +87,11 @@ class ChangelogTest {
                 )
             }
 
-            val config = UpdatariumConfiguration(failfast = false, persistEngine = TestPersistEngine())
+            val config = UpdatariumConfiguration(
+                failfast = false,
+                persistEngine = TestPersistEngine(),
+                listFilesRecursively = true
+            )
             changelog.execute(config)
 
             assertThat((config.persistEngine as TestPersistEngine).changeSetTested).containsExactly(
@@ -126,7 +130,11 @@ class ChangelogTest {
             )
         }
 
-        val config = UpdatariumConfiguration(failfast = true, persistEngine = TestPersistEngine())
+        val config = UpdatariumConfiguration(
+            failfast = true,
+            persistEngine = TestPersistEngine(),
+            listFilesRecursively = true
+        )
         val changelogReport = changelog.execute(config)
         assertThat(changelogReport.changeSetException).hasSize(1)
         with(changelogReport.changeSetException.first()) {

--- a/core/src/test/resources/01/01-changelog.kts
+++ b/core/src/test/resources/01/01-changelog.kts
@@ -15,14 +15,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.saagie.updatarium.config
+import io.saagie.updatarium.dsl.action.BasicAction
+import io.saagie.updatarium.dsl.changeSet
+import io.saagie.updatarium.dsl.changelog
 
-import io.saagie.updatarium.persist.DefaultPersistEngine
-import io.saagie.updatarium.persist.PersistEngine
-
-data class UpdatariumConfiguration(
-    val dryRun: Boolean = false,
-    val failfast: Boolean = true,
-    val persistEngine: PersistEngine = DefaultPersistEngine(),
-    val listFilesRecursively: Boolean = true
-)
+changelog {
+    changesets {
+        +changeSet {
+            id = "ChangeSet-1"
+            author = "HelloWorld"
+            actions {
+                +BasicAction {
+                    logger.info { "Hello world" }
+                }
+            }
+        }
+    }
+}

--- a/core/src/test/resources/01/02/02-changelog_with_tags.kts
+++ b/core/src/test/resources/01/02/02-changelog_with_tags.kts
@@ -15,14 +15,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.saagie.updatarium.config
+import io.saagie.updatarium.dsl.action.BasicAction
+import io.saagie.updatarium.dsl.changeSet
+import io.saagie.updatarium.dsl.changelog
 
-import io.saagie.updatarium.persist.DefaultPersistEngine
-import io.saagie.updatarium.persist.PersistEngine
-
-data class UpdatariumConfiguration(
-    val dryRun: Boolean = false,
-    val failfast: Boolean = true,
-    val persistEngine: PersistEngine = DefaultPersistEngine(),
-    val listFilesRecursively: Boolean = true
-)
+changelog {
+    changesets {
+        +changeSet {
+            id = "ChangeSet-2"
+            author = "HelloWorld"
+            tags = listOf("hello")
+            actions {
+                +BasicAction {
+                    logger.info { "Hello world 2" }
+                }
+            }
+        }
+    }
+}

--- a/updatarium-cli/src/main/kotlin/io/saagie/updatarium/cli/Standalone.kt
+++ b/updatarium-cli/src/main/kotlin/io/saagie/updatarium/cli/Standalone.kt
@@ -53,12 +53,23 @@ class Standalone : CliktCommand(printHelpOnEmptyArgs = true) {
         help = "Changelogs pattern regex (if --changelog is a directory) : `changelog(.*).kts` by default",
         envvar = "UPDATARIUM_CHANGELOGS_PATTERN"
     ).default("changelog(.*).kts")
-    val dryrun by option("--dryrun", "-d",
-        help = "dryRun = when activated, no execution and no lock, just logs")
+    val dryrun by option(
+        "--dryrun", "-d",
+        help = "dryRun = when activated, no execution and no lock, just logs"
+    )
         .flag()
-    val failfast by option("--failfast", "-f",
-        help = "failfast (activated by default) = when activated, stop at the first error")
+    val failfast by option(
+        "--failfast", "-f",
+        help = "failfast (activated by default) = when activated, stop at the first error"
+    )
         .flag("--no-failfast", default = true)
+
+    val listFileRecursively by option(
+        "--recursive", "-R",
+        help = "recursive : list all files traversing directory children"
+    )
+        .flag("--no-recursive", default = true)
+
 
     // PersistEngine options
     val persitEngine by option(help = "Choose the PersitEngine", envvar = "UPDATARIUM_PERSIST_ENGINE").choice(
@@ -103,7 +114,8 @@ class Standalone : CliktCommand(printHelpOnEmptyArgs = true) {
                 persistEngine = when (persitEngine) {
                     MONGODB.name -> MongodbPersistEngine(config)
                     else -> DefaultPersistEngine(config)
-                }
+                },
+                listFilesRecursively = listFileRecursively
             )
 
         )


### PR DESCRIPTION
By default, list all files recursively, and add a way to activate or not this configuration