### PR TITLE
:sparkles: Add force option in the ChangeSet DSL. Fix #81

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,45 @@ In this example, `ChangeSet-bash-1-1` will not be executed.
 Updatarium().executeChangeLog(changeLog,listOf("after")) 
 ```
 
+#### Force execution of changeSet
+
+By default, a changeSet can not be re-executed because of the same ID, like this :
+
+```kotlin
+changeLog {
+    changeSet(id = "ChangeSet-bash-1", author = "Bash") {
+        action {
+            logger.info { "Hello $it!" }
+        }
+    }
+    // Not be executed again
+    changeSet(id = "ChangeSet-bash-1", author = "Bash") {
+        action {
+            logger.info { "Not be executed again" }
+        }
+    }
+}
+```
+
+Because it's run with the `force` option, you can override this behavior like this :
+ 
+```kotlin
+changeLog {
+    changeSet(id = "ChangeSet-bash-1", author = "Bash") {
+        action {
+            logger.info { "Hello $it!" }
+        }
+    }
+    // Will be executed again
+    changeSet(id = "ChangeSet-bash-1", author = "Bash") {
+        force = true
+        action {
+            logger.info { "Will be executed again" }
+        }
+    }
+}
+```
+
 #### PersistConfiguration
 
 You can configure the persistEngine, using a `PersitConfiguration` like this : 

--- a/core/src/main/kotlin/io/saagie/updatarium/model/ChangeSet.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/model/ChangeSet.kt
@@ -23,13 +23,15 @@ import io.saagie.updatarium.log.InMemoryAppenderManager
 import io.saagie.updatarium.model.Status.KO
 import io.saagie.updatarium.model.Status.OK
 import io.saagie.updatarium.model.UpdatariumError.ChangeSetError
+import io.saagie.updatarium.persist.PersistEngine
 import mu.KLoggable
 
 data class ChangeSet(
     val id: String,
     val author: String,
     val tags: List<String> = emptyList(),
-    val actions: List<Action> = emptyList()
+    val actions: List<Action> = emptyList(),
+    val force: Boolean = false
 ) : KLoggable {
     override val logger = logger()
 
@@ -62,7 +64,7 @@ data class ChangeSet(
     fun execute(configuration: UpdatariumConfiguration = UpdatariumConfiguration()): List<ChangeSetError> {
         val exceptions: MutableList<ChangeSetError> = mutableListOf()
         val persistEngine = configuration.persistEngine
-        if (!persistEngine.notAlreadyExecuted(calculateId())) {
+        if (!persistEngine.shouldExecute(this)) {
             logger.info { "$id already executed" }
         } else {
             logger.info { "$id will be executed" }

--- a/core/src/main/kotlin/io/saagie/updatarium/model/dsl.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/model/dsl.kt
@@ -82,6 +82,7 @@ class ChangeSetDsl(val id: String, val author: String) {
     private var actions: MutableList<ActionDsl> = mutableListOf()
 
     var tags: List<Tag> = emptyList()
+    var force: Boolean = false
 
     fun action(name: String = "basicAction", block: ActionDsl.() -> Unit) =
         this.actions.add(ActionDsl(name, block))
@@ -97,7 +98,8 @@ class ChangeSetDsl(val id: String, val author: String) {
             id = id,
             author = author,
             tags = tags,
-            actions = actions.map(ActionDsl::build)
+            actions = actions.map(ActionDsl::build),
+            force = force
         )
 }
 

--- a/core/src/main/kotlin/io/saagie/updatarium/persist/PersistEngine.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/persist/PersistEngine.kt
@@ -17,6 +17,7 @@
  */
 package io.saagie.updatarium.persist
 
+import io.saagie.updatarium.model.ChangeLog
 import io.saagie.updatarium.model.ChangeSet
 import io.saagie.updatarium.model.Status
 import mu.KLoggable
@@ -39,6 +40,18 @@ abstract class PersistEngine(open val configuration: PersistConfig) : KLoggable 
      * Return true if the changeset has never be ran, false otherwise.
      */
     abstract fun notAlreadyExecuted(changeSetId: String): Boolean
+
+    /**
+     * This function will check if a changset should be executed based on the property "force" and the method [notAlreadyExecuted].
+     * Return true if should execute, false otherwise.
+     */
+    fun shouldExecute(changeSet: ChangeSet): Boolean =
+        if (changeSet.force) {
+            logger.warn { "${changeSet.id} is marked as forced, will be executed !" }
+            true
+        } else {
+            notAlreadyExecuted(changeSet.calculateId())
+        }
 
     /**
      * This function is here to "lock" the changeset, that's mean store a reference thant the changeset in parameter will be execute.

--- a/core/src/test/kotlin/io/saagie/updatarium/persist/TestPersistEngine.kt
+++ b/core/src/test/kotlin/io/saagie/updatarium/persist/TestPersistEngine.kt
@@ -20,17 +20,21 @@ package io.saagie.updatarium.persist
 import io.saagie.updatarium.model.ChangeSet
 import io.saagie.updatarium.model.Status
 
-class TestPersistEngine : PersistEngine(PersistConfig()){
+class TestPersistEngine : PersistEngine(PersistConfig()) {
     val changeSetTested = mutableListOf<String>()
-    val changeSetLocked = mutableListOf<ChangeSet>()
+    private val changeSetLocked = mutableListOf<ChangeSet>()
     val changeSetUnLocked = mutableListOf<Pair<ChangeSet, Status>>()
 
     override fun checkConnection() {
     }
 
     override fun notAlreadyExecuted(changeSetId: String): Boolean {
-        changeSetTested.add(changeSetId)
-        return true
+        return if (!changeSetTested.contains(changeSetId)) {
+            changeSetTested.add(changeSetId)
+            true
+        } else {
+            false
+        }
     }
 
     override fun lock(changeSet: ChangeSet) {

--- a/samples/basic-multiplechangelog/src/main/resources/changelogs/changelog4.kts
+++ b/samples/basic-multiplechangelog/src/main/resources/changelogs/changelog4.kts
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2019-2020 Pierre Leresteux.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import io.saagie.updatarium.model.changeLog
+
+changeLog {
+    changeSet(id = "ChangeSet-bash-1", author = "Bash") {
+        action {
+            (1..5).forEach {
+                logger.info { "Hello $it!" }
+            }
+        }
+    }
+    changeSet(id = "ChangeSet-bash-1", author = "Bash") {
+        force = true
+        action {
+            (1..5).forEach {
+                logger.info { "Hello $it!" }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add force to changeSet DSL, with tests and Doc :
```kotlin
changeLog {
    changeSet(id = "ChangeSet-bash-1", author = "Bash") {
        action {
            logger.info { "Hello $it!" }
        }
    }
    // Will be executed again
    changeSet(id = "ChangeSet-bash-1", author = "Bash") {
        force = true
        action {
            logger.info { "Will be executed again" }
        }
    }
}
```