### PR TITLE
Stop execution if an alreadyExecuted failing changeset is found

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,20 +62,20 @@ Now you can create your own implementation of `PersistEngine`.
 
 ```$kotlin
    abstract fun checkConnection()
-   abstract fun notAlreadyExecuted(changeSetId: String): Boolean
+   abstract fun findLatestExecutionStatus(changeSetId: String): ExecutionStatus
    abstract fun lock(changeSet: ChangeSet)
-   abstract fun unlock(changeSet: ChangeSet, status: Status, logs: List<String>)
+   abstract fun unlock(changeSet: ChangeSet, status: ExecutionStatus, logs: List<String>)
 ```
 
 Let's see in details each function : 
 
 - `checkConnection()` is called before starting the changelog execution to check that the persistence is ready (checking a database connection for example). This function returns nothing, you have to throw an exception is the persistence is not ready and it will stop the process.
 
-- `notAlreadyExecuted(changeSetId: String)` is called at the changeset execution beginning. You have to check in your persistence engine (database ? file ? memory ? ) if you have previously executed this changesetId. Return true to allow this changeset execution, false otherwise.
+- `notAlreadyExecuted(changeSetId: String)` is called at the changeSet execution beginning. You have to check in your persistence engine (database ? file ? memory ? ) if you have previously executed this changeSetId. Return `ExecutionStatus.NOT_EXECUTED` to allow this changeSet execution, the persisted execution status otherwise.
 
-- `lock(changeSet: ChangeSet)` is called just before execute the changeset actions. You have to record the changeset execution in your persistence engine (with a `Status.EXECUTE` status).
+- `lock(changeSet: ChangeSet)` is called just before execute the changeSet actions. You have to record the changeSet execution in your persistence engine (with an `ExecutionStatus.EXECUTE` status).
 
-- `unlock(changeSet: ChangeSet,status: Status, logs: List<String>)` is called a the end of the actions execution for a changeset. You have the correct status (`Status.OK` or `Status.KO`) and an ordered list containing all LogEvent captured during the execution of the changeset, and you can update this new status to the changeset record and store logs (if PersistConfig is set to not store logs, the list is empty)
+- `unlock(changeSet: ChangeSet, status: ExecutionStatus, logs: List<String>)` is called at the end of actions execution for a changeSet. You have the correct status (`ExecutionStatus.OK` or `ExecutionStatus.FAIL`) and an ordered list containing all LogEvent captured during the execution of the changeSet, and you can update this new status to the changeSet record and store logs (if PersistConfig is set to not store logs, the list is empty)
 
 ## Code of Conduct
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,6 +98,18 @@ config {
                 email = "igor.laborie@saagie.com"
                 roles = listOf("developer")
             }
+            person {
+                id = "antoine"
+                name = "Antoine Carton"
+                email = "antoine.carton@saagie.com"
+                roles = listOf("developer")
+            }
+            person {
+                id = "y-henry"
+                name = "Yohann Henry"
+                email = "yohann.henry@saagie.com"
+                roles = listOf("developer")
+            }
         }
 
         bintray {

--- a/core/src/main/kotlin/io/saagie/updatarium/model/ChangeSet.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/model/ChangeSet.kt
@@ -18,7 +18,8 @@
 package io.saagie.updatarium.model
 
 import io.saagie.updatarium.config.UpdatariumConfiguration
-import io.saagie.updatarium.model.Status.NOT_EXECUTED
+import io.saagie.updatarium.model.ExecutionStatus.FAIL
+import io.saagie.updatarium.model.ExecutionStatus.NOT_EXECUTED
 import io.saagie.updatarium.model.UpdatariumError.ChangeSetError
 import mu.KLoggable
 
@@ -83,6 +84,10 @@ data class ChangeSet(
             logger.warn { "$executionId marked as forced. Will be executed" }
             true
         } else {
-            configuration.persistEngine.notAlreadyExecuted(executionId) == NOT_EXECUTED
+            when (configuration.persistEngine.findLatestExecutionStatus(executionId)) {
+                NOT_EXECUTED -> true
+                FAIL -> throw UpdatariumError.AlreadyExecutedAndInError(executionId)
+                else -> false
+            }
         }
 }

--- a/core/src/main/kotlin/io/saagie/updatarium/model/ChangeSet.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/model/ChangeSet.kt
@@ -18,6 +18,7 @@
 package io.saagie.updatarium.model
 
 import io.saagie.updatarium.config.UpdatariumConfiguration
+import io.saagie.updatarium.model.Status.NOT_EXECUTED
 import io.saagie.updatarium.model.UpdatariumError.ChangeSetError
 import mu.KLoggable
 
@@ -82,6 +83,6 @@ data class ChangeSet(
             logger.warn { "$executionId marked as forced. Will be executed" }
             true
         } else {
-            configuration.persistEngine.notAlreadyExecuted(executionId)
+            configuration.persistEngine.notAlreadyExecuted(executionId) == NOT_EXECUTED
         }
 }

--- a/core/src/main/kotlin/io/saagie/updatarium/model/ExecutionStatus.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/model/ExecutionStatus.kt
@@ -18,9 +18,9 @@
 package io.saagie.updatarium.model
 
 /**
- * Represent the status of the changeset.
+ * Represent the status of the changeSet.
  */
-enum class Status {
+enum class ExecutionStatus {
     // never executed
     NOT_EXECUTED,
     // execution in progress
@@ -28,5 +28,5 @@ enum class Status {
     // Execution is done with a correct status
     OK,
     // Execution is done but it has failed
-    KO
+    FAIL
 }

--- a/core/src/main/kotlin/io/saagie/updatarium/model/Status.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/model/Status.kt
@@ -21,6 +21,8 @@ package io.saagie.updatarium.model
  * Represent the status of the changeset.
  */
 enum class Status {
+    // never executed
+    NOT_EXECUTED,
     // execution in progress
     EXECUTE,
     // Execution is done with a correct status

--- a/core/src/main/kotlin/io/saagie/updatarium/model/UpdatariumError.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/model/UpdatariumError.kt
@@ -19,5 +19,6 @@ package io.saagie.updatarium.model
 
 sealed class UpdatariumError(open val e: Throwable?) : Exception() {
     data class ChangeSetError(val changeSet: ChangeSet, override val e: Throwable? = null) : UpdatariumError(e)
+    data class AlreadyExecutedAndInError(val executionId: String) : UpdatariumError(null)
     object ExitError : UpdatariumError(null)
 }

--- a/core/src/main/kotlin/io/saagie/updatarium/persist/DefaultPersistEngine.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/persist/DefaultPersistEngine.kt
@@ -18,8 +18,8 @@
 package io.saagie.updatarium.persist
 
 import io.saagie.updatarium.model.ChangeSet
-import io.saagie.updatarium.model.Status
-import io.saagie.updatarium.model.Status.NOT_EXECUTED
+import io.saagie.updatarium.model.ExecutionStatus
+import io.saagie.updatarium.model.ExecutionStatus.NOT_EXECUTED
 
 /**
  * This is a basic implementation of the PersistEngine.
@@ -37,13 +37,13 @@ class DefaultPersistEngine(
         logger.warn { "***********************" }
     }
 
-    override fun notAlreadyExecuted(changeSetId: String): Status = NOT_EXECUTED
+    override fun findLatestExecutionStatus(changeSetId: String): ExecutionStatus = NOT_EXECUTED
 
     override fun lock(executionId: String, changeSet: ChangeSet) {
-        logger.info { "$executionId marked as ${Status.EXECUTE}" }
+        logger.info { "$executionId marked as ${ExecutionStatus.EXECUTE}" }
     }
 
-    override fun unlock(executionId: String, changeSet: ChangeSet, status: Status, logs: List<String>) {
+    override fun unlock(executionId: String, changeSet: ChangeSet, status: ExecutionStatus, logs: List<String>) {
         logger.info { "$executionId marked as $status" }
         logger.info { logs }
     }

--- a/core/src/main/kotlin/io/saagie/updatarium/persist/DefaultPersistEngine.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/persist/DefaultPersistEngine.kt
@@ -19,6 +19,7 @@ package io.saagie.updatarium.persist
 
 import io.saagie.updatarium.model.ChangeSet
 import io.saagie.updatarium.model.Status
+import io.saagie.updatarium.model.Status.NOT_EXECUTED
 
 /**
  * This is a basic implementation of the PersistEngine.
@@ -36,7 +37,7 @@ class DefaultPersistEngine(
         logger.warn { "***********************" }
     }
 
-    override fun notAlreadyExecuted(changeSetId: String): Boolean = true
+    override fun notAlreadyExecuted(changeSetId: String): Status = NOT_EXECUTED
 
     override fun lock(executionId: String, changeSet: ChangeSet) {
         logger.info { "$executionId marked as ${Status.EXECUTE}" }

--- a/core/src/main/kotlin/io/saagie/updatarium/persist/PersistEngine.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/persist/PersistEngine.kt
@@ -41,7 +41,7 @@ abstract class PersistEngine(open val configuration: PersistConfig) {
      * This function will check that the changeSet (by its ID) have never been run.
      * Return true if the changeSet has never been run, false otherwise.
      */
-    abstract fun notAlreadyExecuted(changeSetId: String): Boolean
+    abstract fun notAlreadyExecuted(changeSetId: String): Status
 
     /**
      * This function is here to "lock" the changeSet, that's mean store a reference thant the changeSet in the parameter will be executed.

--- a/core/src/main/kotlin/io/saagie/updatarium/persist/PersistEngine.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/persist/PersistEngine.kt
@@ -20,7 +20,7 @@ package io.saagie.updatarium.persist
 import io.saagie.updatarium.log.InMemoryAppenderAccess
 import io.saagie.updatarium.log.InMemoryAppenderManager
 import io.saagie.updatarium.model.ChangeSet
-import io.saagie.updatarium.model.Status
+import io.saagie.updatarium.model.ExecutionStatus
 import mu.KotlinLogging
 
 /**
@@ -38,10 +38,10 @@ abstract class PersistEngine(open val configuration: PersistConfig) {
     abstract fun checkConnection()
 
     /**
-     * This function will check that the changeSet (by its ID) have never been run.
-     * Return true if the changeSet has never been run, false otherwise.
+     * This function will return the latest changeSet execution status (by its ID).
+     * Return Status.NOT_EXECUTED if the changeSet has never been run, the persisted Status otherwise.
      */
-    abstract fun notAlreadyExecuted(changeSetId: String): Status
+    abstract fun findLatestExecutionStatus(changeSetId: String): ExecutionStatus
 
     /**
      * This function is here to "lock" the changeSet, that's mean store a reference thant the changeSet in the parameter will be executed.
@@ -53,7 +53,7 @@ abstract class PersistEngine(open val configuration: PersistConfig) {
     /**
      * This function is called after the changeSet execution, so you can now update the changeSet status (in the parameter) and store the logs.
      */
-    protected abstract fun unlock(executionId: String, changeSet: ChangeSet, status: Status, logs: List<String>)
+    protected abstract fun unlock(executionId: String, changeSet: ChangeSet, status: ExecutionStatus, logs: List<String>)
 
     /**
      * Run changeSet code, and possibly lock the changeSet before
@@ -71,18 +71,18 @@ abstract class PersistEngine(open val configuration: PersistConfig) {
                 lock(executionId, this)
             }
             InMemoryAppenderManager.record { block() }
-            logger.info { "$executionId marked as ${Status.OK}" }
+            logger.info { "$executionId marked as ${ExecutionStatus.OK}" }
             if (lock) {
                 val logs = InMemoryAppenderAccess.getEvents(persistConfig = configuration, success = true)
-                unlock(executionId, this, Status.OK, logs)
+                unlock(executionId, this, ExecutionStatus.OK, logs)
             }
             null
         } catch (e: Exception) {
             logger.error(e) { "Error during apply update" }
-            logger.info { "$executionId marked as ${Status.KO}" }
+            logger.info { "$executionId marked as ${ExecutionStatus.FAIL}" }
             if (lock) {
                 val logs = InMemoryAppenderAccess.getEvents(persistConfig = configuration, success = false)
-                unlock(executionId, this, Status.KO, logs)
+                unlock(executionId, this, ExecutionStatus.FAIL, logs)
             }
             e
         }

--- a/core/src/test/kotlin/io/saagie/updatarium/UpdatariumITest.kt
+++ b/core/src/test/kotlin/io/saagie/updatarium/UpdatariumITest.kt
@@ -354,7 +354,7 @@ class UpdatariumITest {
                         .extracting { "${it.executionId}-${it.status.name}" }
                         .containsExactly(
                             "${failedChangelogPath.toAbsolutePath()}_ChangeSet-1-OK",
-                            "${failedChangelogPath.toAbsolutePath()}_ChangeSet-2-KO"
+                            "${failedChangelogPath.toAbsolutePath()}_ChangeSet-2-FAIL"
                         )
                 }
             }
@@ -380,7 +380,7 @@ class UpdatariumITest {
                         .extracting { "${it.executionId}-${it.status.name}" }
                         .containsExactly(
                             "${failedChangelogPath.toAbsolutePath()}_ChangeSet-1-OK",
-                            "${failedChangelogPath.toAbsolutePath()}_ChangeSet-2-KO",
+                            "${failedChangelogPath.toAbsolutePath()}_ChangeSet-2-FAIL",
                             "${failedChangelogPath.toAbsolutePath()}_ChangeSet-3-OK"
                         )
                 }
@@ -403,7 +403,7 @@ class UpdatariumITest {
                         .extracting { "${it.executionId}-${it.status.name}" }
                         .containsExactly(
                             "${failedChangelogPath.toAbsolutePath()}_ChangeSet-1-OK",
-                            "${failedChangelogPath.toAbsolutePath()}_ChangeSet-2-KO"
+                            "${failedChangelogPath.toAbsolutePath()}_ChangeSet-2-FAIL"
                         )
                 }
             }
@@ -426,7 +426,7 @@ class UpdatariumITest {
                         .extracting { "${it.executionId}-${it.status.name}" }
                         .containsExactly(
                             "${failedChangelogPath.toAbsolutePath()}_ChangeSet-1-OK",
-                            "${failedChangelogPath.toAbsolutePath()}_ChangeSet-2-KO",
+                            "${failedChangelogPath.toAbsolutePath()}_ChangeSet-2-FAIL",
                             "${failedChangelogPath.toAbsolutePath()}_ChangeSet-3-OK"
                         )
                 }

--- a/core/src/test/kotlin/io/saagie/updatarium/model/ChangeLogTest.kt
+++ b/core/src/test/kotlin/io/saagie/updatarium/model/ChangeLogTest.kt
@@ -95,7 +95,7 @@ class ChangeLogTest {
             assertThat(
                 (config.persistEngine as TestPersistEngine).changeSetUnLocked
                     .map { "${it.executionId}-${it.status}" }).containsExactly(
-                "changeSet1-KO",
+                "changeSet1-FAIL",
                 "changeSet2-OK"
             )
         }
@@ -128,7 +128,7 @@ class ChangeLogTest {
             )
             assertThat(
                 (config.persistEngine as TestPersistEngine).changeSetUnLocked
-                    .map { "${it.executionId}-${it.status}" }).containsExactly("changeSet1-KO")
+                    .map { "${it.executionId}-${it.status}" }).containsExactly("changeSet1-FAIL")
         }
     }
 

--- a/core/src/test/kotlin/io/saagie/updatarium/persist/TestPersistEngine.kt
+++ b/core/src/test/kotlin/io/saagie/updatarium/persist/TestPersistEngine.kt
@@ -19,6 +19,8 @@ package io.saagie.updatarium.persist
 
 import io.saagie.updatarium.model.ChangeSet
 import io.saagie.updatarium.model.Status
+import io.saagie.updatarium.model.Status.NOT_EXECUTED
+import io.saagie.updatarium.model.Status.OK
 
 class TestPersistEngine : PersistEngine(PersistConfig()) {
     data class ChangeSetUnLocked(val executionId: String, val changeSet: ChangeSet, val status: Status)
@@ -30,10 +32,13 @@ class TestPersistEngine : PersistEngine(PersistConfig()) {
     override fun checkConnection() {
     }
 
-    override fun notAlreadyExecuted(changeSetId: String): Boolean {
+    override fun notAlreadyExecuted(changeSetId: String): Status {
         val notAlreadyExecuted = changeSetId !in changeSetTested
         changeSetTested.add(changeSetId)
-        return notAlreadyExecuted
+        if (notAlreadyExecuted) {
+            return NOT_EXECUTED
+        }
+        return OK
     }
 
     override fun lock(executionId: String, changeSet: ChangeSet) {

--- a/core/src/test/kotlin/io/saagie/updatarium/persist/TestPersistEngine.kt
+++ b/core/src/test/kotlin/io/saagie/updatarium/persist/TestPersistEngine.kt
@@ -18,12 +18,11 @@
 package io.saagie.updatarium.persist
 
 import io.saagie.updatarium.model.ChangeSet
-import io.saagie.updatarium.model.Status
-import io.saagie.updatarium.model.Status.NOT_EXECUTED
-import io.saagie.updatarium.model.Status.OK
+import io.saagie.updatarium.model.ExecutionStatus
+import io.saagie.updatarium.model.ExecutionStatus.NOT_EXECUTED
 
 class TestPersistEngine : PersistEngine(PersistConfig()) {
-    data class ChangeSetUnLocked(val executionId: String, val changeSet: ChangeSet, val status: Status)
+    data class ChangeSetUnLocked(val executionId: String, val changeSet: ChangeSet, val status: ExecutionStatus)
 
     val changeSetTested = mutableListOf<String>()
     val changeSetLocked = mutableListOf<ChangeSet>()
@@ -32,20 +31,20 @@ class TestPersistEngine : PersistEngine(PersistConfig()) {
     override fun checkConnection() {
     }
 
-    override fun notAlreadyExecuted(changeSetId: String): Status {
+    override fun findLatestExecutionStatus(changeSetId: String): ExecutionStatus {
         val notAlreadyExecuted = changeSetId !in changeSetTested
         changeSetTested.add(changeSetId)
         if (notAlreadyExecuted) {
             return NOT_EXECUTED
         }
-        return OK
+        return changeSetUnLocked.first { it.executionId == changeSetId }.status
     }
 
     override fun lock(executionId: String, changeSet: ChangeSet) {
         changeSetLocked.add(changeSet)
     }
 
-    override fun unlock(executionId: String, changeSet: ChangeSet, status: Status, logs: List<String>) {
+    override fun unlock(executionId: String, changeSet: ChangeSet, status: ExecutionStatus, logs: List<String>) {
         changeSetUnLocked.add(ChangeSetUnLocked(executionId, changeSet, status))
     }
 }

--- a/persist-mongodb/src/main/kotlin/io/saagie/updatarium/persist/MongodbPersistEngine.kt
+++ b/persist-mongodb/src/main/kotlin/io/saagie/updatarium/persist/MongodbPersistEngine.kt
@@ -21,14 +21,11 @@ import com.mongodb.ConnectionString
 import com.mongodb.client.model.IndexOptions
 import com.mongodb.client.model.Indexes
 import io.saagie.updatarium.model.ChangeSet
-import io.saagie.updatarium.model.Status
-import io.saagie.updatarium.model.Status.NOT_EXECUTED
+import io.saagie.updatarium.model.ExecutionStatus
+import io.saagie.updatarium.model.ExecutionStatus.NOT_EXECUTED
 import io.saagie.updatarium.persist.model.MongoDbChangeSet
 import io.saagie.updatarium.persist.model.toMongoDbDocument
-import org.litote.kmongo.KMongo
-import org.litote.kmongo.eq
-import org.litote.kmongo.findOne
-import org.litote.kmongo.getCollection
+import org.litote.kmongo.*
 import java.time.Instant
 
 const val MONGODB_PERSIST_CONNECTIONSTRING = "MONGODB_PERSIST_CONNECTIONSTRING"
@@ -61,35 +58,43 @@ class MongodbPersistEngine(override val configuration: PersistConfig = PersistCo
         logger.info { "Connection to mongodb instance : successful" }
     }
 
-    override fun notAlreadyExecuted(changeSetId: String): Status {
-        when (val doc = collection.findOne(MongoDbChangeSet::changeSetId eq changeSetId)) {
+    override fun findLatestExecutionStatus(changeSetId: String): ExecutionStatus =
+        when (val doc = getLastRecordedChangeSet(changeSetId)) {
             null -> {
                 logger.info { "$changeSetId not exists" }
-                return NOT_EXECUTED
+                NOT_EXECUTED
             }
             else -> {
-                when (doc.status) {
-                    Status.OK.name -> {
-                        logger.info { "$changeSetId already executed : OK" }
-                    }
-                    Status.EXECUTE.name -> {
-                        logger.info { "$changeSetId already in progress ?" }
-                    }
-                    else -> {
-                        logger.warn { "$changeSetId was already executed in error" }
-                    }
-                }
-                return Status.valueOf(doc.status)
+                logStatus(changeSetId, doc.status)
+                ExecutionStatus.valueOf(doc.status)
+            }
+        }
+
+    private fun logStatus(changeSetId: String, status: String) {
+        when (status) {
+            ExecutionStatus.OK.name -> {
+                logger.info { "$changeSetId already executed : OK" }
+            }
+            ExecutionStatus.EXECUTE.name -> {
+                logger.info { "$changeSetId already in progress ?" }
+            }
+            else -> {
+                logger.warn { "$changeSetId was already executed in error" }
             }
         }
     }
 
+    private fun getLastRecordedChangeSet(changeSetId: String) : MongoDbChangeSet? =
+        collection.find(MongoDbChangeSet::changeSetId eq changeSetId)
+            .sort(descending(MongoDbChangeSet::statusDate))
+            .first()
+
     override fun lock(executionId: String, changeSet: ChangeSet) {
         collection.insertOne(changeSet.toMongoDbDocument(executionId))
-        logger.info { "$executionId marked as ${Status.EXECUTE}" }
+        logger.info { "$executionId marked as ${ExecutionStatus.EXECUTE}" }
     }
 
-    override fun unlock(executionId: String, changeSet: ChangeSet, status: Status, logs: List<String>) {
+    override fun unlock(executionId: String, changeSet: ChangeSet, status: ExecutionStatus, logs: List<String>) {
         collection.insertOne(
             changeSet.toMongoDbDocument(executionId).copy(
                 status = status.name,

--- a/persist-mongodb/src/main/kotlin/io/saagie/updatarium/persist/model/MongoDbChangeSet.kt
+++ b/persist-mongodb/src/main/kotlin/io/saagie/updatarium/persist/model/MongoDbChangeSet.kt
@@ -18,7 +18,7 @@
 package io.saagie.updatarium.persist.model
 
 import io.saagie.updatarium.model.ChangeSet
-import io.saagie.updatarium.model.Status
+import io.saagie.updatarium.model.ExecutionStatus
 import java.time.Instant
 
 data class MongoDbChangeSet(
@@ -34,7 +34,7 @@ data class MongoDbChangeSet(
 fun ChangeSet.toMongoDbDocument(executionId: String): MongoDbChangeSet = MongoDbChangeSet(
     changeSetId = executionId,
     author = this.author,
-    status = Status.EXECUTE.name,
+    status = ExecutionStatus.EXECUTE.name,
     force = this.force,
     log = mutableListOf()
 )


### PR DESCRIPTION
If we try to execute a changeSet already executed but with a fail status, an exception should be thrown to stop the current execution