### PR TITLE
:sparkles: Add persist engine admin cli

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -1,6 +1,8 @@
 name: Build All
 
 on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
   push:
     branches:
       - '*'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,13 +58,19 @@ You need to create a new Kotlin project and just add the
 Now you can create your own implementation of `PersistEngine`.  
 
 
-`PersistEngine` interface contains four functions : 
+`PersistEngine` interface contains some functions : 
 
 ```$kotlin
    abstract fun checkConnection()
    abstract fun findLatestExecutionStatus(changeSetId: String): ExecutionStatus
    abstract fun lock(changeSet: ChangeSet)
    abstract fun unlock(changeSet: ChangeSet, status: ExecutionStatus, logs: List<String>)
+   abstract fun findExecutions(
+       page: PageRequest = PageRequest(),
+       filterStatus: Set<ExecutionStatus> = ExecutionStatus.values().toSet(),
+       filterChangeSetId: String? = null
+   ): List<ExecutionReport>
+   abstract fun executionCount(): Int
 ```
 
 Let's see in details each function : 
@@ -76,6 +82,11 @@ Let's see in details each function :
 - `lock(changeSet: ChangeSet)` is called just before execute the changeSet actions. You have to record the changeSet execution in your persistence engine (with an `ExecutionStatus.EXECUTE` status).
 
 - `unlock(changeSet: ChangeSet, status: ExecutionStatus, logs: List<String>)` is called at the end of actions execution for a changeSet. You have the correct status (`ExecutionStatus.OK` or `ExecutionStatus.FAIL`) and an ordered list containing all LogEvent captured during the execution of the changeSet, and you can update this new status to the changeSet record and store logs (if PersistConfig is set to not store logs, the list is empty)
+
+- `findExecutions(page: PageRequest, filterStatus: Set<ExecutionStatus>, filterChangeSetId: String)` 
+allows the administration cli to get the execution information to display them.
+
+- `executionCount()` is for the cli to administrate the change set executions.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,10 @@ You'll find in the sample directory some examples to use Updatarium.
 
 A command line module to provide an all-in-one application a ship it into a Docker image ([saagie/updatarium](https://hub.docker.com/r/saagie/updatarium)))
 
+- ##### updatarium-admin-cli
+
+A command line module to help to administrate the persist engine. It can display the execution historics.
+
 ### Credits
 Logo : 
  - Made by [@pierreLeresteux](https://github.com/pierreLeresteux)

--- a/core/src/main/kotlin/io/saagie/updatarium/model/ExecutionReport.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/model/ExecutionReport.kt
@@ -15,20 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-rootProject.name = "updatarium"
-include(":core")
-include(":persist-mongodb")
-include(":engine-bash")
-include(":engine-mongodb")
-include(":engine-kubernetes")
-include(":engine-httpclient")
-include(":samples:basic")
-include(":samples:basic-mongodbpersist")
-include(":samples:basic-multiplechangelog")
-include(":samples:basic-multiplechangelog-withtag")
-include(":samples:http")
-include(":samples:bash")
-include(":samples:mongodb")
-include(":samples:kubernetes")
-include(":updatarium-cli")
-include(":updatarium-admin-cli")
+package io.saagie.updatarium.model
+
+import java.time.Instant
+
+data class ExecutionReport(
+    val executionId: String,
+    val changeSetId: String,
+    val author: String,
+    val status: ExecutionStatus,
+    val statusDate: Instant,
+    val forced: Boolean = false
+)

--- a/core/src/main/kotlin/io/saagie/updatarium/persist/DefaultPersistEngine.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/persist/DefaultPersistEngine.kt
@@ -18,8 +18,10 @@
 package io.saagie.updatarium.persist
 
 import io.saagie.updatarium.model.ChangeSet
+import io.saagie.updatarium.model.ExecutionReport
 import io.saagie.updatarium.model.ExecutionStatus
 import io.saagie.updatarium.model.ExecutionStatus.NOT_EXECUTED
+import io.saagie.updatarium.persist.model.PageRequest
 
 /**
  * This is a basic implementation of the PersistEngine.
@@ -38,6 +40,13 @@ class DefaultPersistEngine(
     }
 
     override fun findLatestExecutionStatus(changeSetId: String): ExecutionStatus = NOT_EXECUTED
+    override fun findExecutions(
+        page: PageRequest,
+        filterStatus: Set<ExecutionStatus>,
+        filterChangeSetId: String?
+    ): List<ExecutionReport> = emptyList()
+
+    override fun executionCount(): Int = 0
 
     override fun lock(executionId: String, changeSet: ChangeSet) {
         logger.info { "$executionId marked as ${ExecutionStatus.EXECUTE}" }

--- a/core/src/main/kotlin/io/saagie/updatarium/persist/PersistEngine.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/persist/PersistEngine.kt
@@ -20,7 +20,9 @@ package io.saagie.updatarium.persist
 import io.saagie.updatarium.log.InMemoryAppenderAccess
 import io.saagie.updatarium.log.InMemoryAppenderManager
 import io.saagie.updatarium.model.ChangeSet
+import io.saagie.updatarium.model.ExecutionReport
 import io.saagie.updatarium.model.ExecutionStatus
+import io.saagie.updatarium.persist.model.PageRequest
 import mu.KotlinLogging
 
 /**
@@ -42,6 +44,21 @@ abstract class PersistEngine(open val configuration: PersistConfig) {
      * Return Status.NOT_EXECUTED if the changeSet has never been run, the persisted Status otherwise.
      */
     abstract fun findLatestExecutionStatus(changeSetId: String): ExecutionStatus
+
+    /**
+     * This function will return the executions filtered by status and optionally by change set.
+     * The result is paginated depending of the page argument.
+     */
+    abstract fun findExecutions(
+        page: PageRequest = PageRequest(),
+        filterStatus: Set<ExecutionStatus> = ExecutionStatus.values().toSet(),
+        filterChangeSetId: String? = null
+    ): List<ExecutionReport>
+
+    /**
+     * This function returns the count of changeSet executions.
+     */
+    abstract fun executionCount(): Int
 
     /**
      * This function is here to "lock" the changeSet, that's mean store a reference thant the changeSet in the parameter will be executed.

--- a/core/src/main/kotlin/io/saagie/updatarium/persist/PersistEngine.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/persist/PersistEngine.kt
@@ -70,7 +70,12 @@ abstract class PersistEngine(open val configuration: PersistConfig) {
     /**
      * This function is called after the changeSet execution, so you can now update the changeSet status (in the parameter) and store the logs.
      */
-    protected abstract fun unlock(executionId: String, changeSet: ChangeSet, status: ExecutionStatus, logs: List<String>)
+    protected abstract fun unlock(
+        executionId: String,
+        changeSet: ChangeSet,
+        status: ExecutionStatus,
+        logs: List<String>
+    )
 
     /**
      * Run changeSet code, and possibly lock the changeSet before

--- a/core/src/main/kotlin/io/saagie/updatarium/persist/model/PageRequest.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/persist/model/PageRequest.kt
@@ -15,20 +15,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-rootProject.name = "updatarium"
-include(":core")
-include(":persist-mongodb")
-include(":engine-bash")
-include(":engine-mongodb")
-include(":engine-kubernetes")
-include(":engine-httpclient")
-include(":samples:basic")
-include(":samples:basic-mongodbpersist")
-include(":samples:basic-multiplechangelog")
-include(":samples:basic-multiplechangelog-withtag")
-include(":samples:http")
-include(":samples:bash")
-include(":samples:mongodb")
-include(":samples:kubernetes")
-include(":updatarium-cli")
-include(":updatarium-admin-cli")
+package io.saagie.updatarium.persist.model
+
+data class PageRequest(
+    val size: Int = 10,
+    val skip: Int = 0,
+    val order: Sort = Sort.DESC
+) {
+    init {
+        require(size > 0) {
+            "size should be greater than 0, $size was found"
+        }
+        require(skip >= 0) {
+            "skip should be greater or equal to 0, $skip was found"
+        }
+    }
+}

--- a/core/src/main/kotlin/io/saagie/updatarium/persist/model/Sort.kt
+++ b/core/src/main/kotlin/io/saagie/updatarium/persist/model/Sort.kt
@@ -15,20 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-rootProject.name = "updatarium"
-include(":core")
-include(":persist-mongodb")
-include(":engine-bash")
-include(":engine-mongodb")
-include(":engine-kubernetes")
-include(":engine-httpclient")
-include(":samples:basic")
-include(":samples:basic-mongodbpersist")
-include(":samples:basic-multiplechangelog")
-include(":samples:basic-multiplechangelog-withtag")
-include(":samples:http")
-include(":samples:bash")
-include(":samples:mongodb")
-include(":samples:kubernetes")
-include(":updatarium-cli")
-include(":updatarium-admin-cli")
+package io.saagie.updatarium.persist.model
+
+enum class Sort {
+    ASC,
+    DESC
+}

--- a/core/src/test/kotlin/io/saagie/updatarium/UpdatariumITest.kt
+++ b/core/src/test/kotlin/io/saagie/updatarium/UpdatariumITest.kt
@@ -309,7 +309,11 @@ class UpdatariumITest {
                     changeLog(id = "Plop") {
                         changeSet(id = "ChangeSet-1", author = "Hello World") {
                             force = false // by default
-                            action { logger.info { "This ChangeSet-1 must not be run as it is already run and not forced" } }
+                            action {
+                                logger.info {
+                                    "This ChangeSet-1 must not be run as it is already run and not forced"
+                                }
+                            }
                         }
                     }
                 )
@@ -323,7 +327,8 @@ class UpdatariumITest {
                         }
                     }
                 )
-            assertThat((this.persistEngine as TestPersistEngine).changeSetTested).hasSize(2) // Third time is not tested (forced)
+            assertThat((this.persistEngine as TestPersistEngine).changeSetTested)
+                .hasSize(2) // Third time is not tested (forced)
             assertThat((this.persistEngine as TestPersistEngine).changeSetTested)
                 .containsExactly("Plop_ChangeSet-1", "Plop_ChangeSet-1")
             assertThat((this.persistEngine as TestPersistEngine).changeSetUnLocked)

--- a/core/src/test/kotlin/io/saagie/updatarium/model/ChangeSetTest.kt
+++ b/core/src/test/kotlin/io/saagie/updatarium/model/ChangeSetTest.kt
@@ -151,7 +151,8 @@ class ChangeSetTest {
         assertThat(changedSetForcedUnlocked.status).isEqualTo(ExecutionStatus.OK)
 
         assertThat(changeSetsUnLocked.count { it.changeSet == changeSet }).isEqualTo(1) // Run once
-        assertThat(changeSetsUnLocked.count { it.changeSet == changeSetForced }).isEqualTo(2) // Run twice as it is forced
+        assertThat(changeSetsUnLocked.count { it.changeSet == changeSetForced })
+            .isEqualTo(2) // Run twice as it is forced
     }
 
     @Test

--- a/core/src/test/kotlin/io/saagie/updatarium/persist/TestPersistEngine.kt
+++ b/core/src/test/kotlin/io/saagie/updatarium/persist/TestPersistEngine.kt
@@ -18,8 +18,10 @@
 package io.saagie.updatarium.persist
 
 import io.saagie.updatarium.model.ChangeSet
+import io.saagie.updatarium.model.ExecutionReport
 import io.saagie.updatarium.model.ExecutionStatus
 import io.saagie.updatarium.model.ExecutionStatus.NOT_EXECUTED
+import io.saagie.updatarium.persist.model.PageRequest
 
 class TestPersistEngine : PersistEngine(PersistConfig()) {
     data class ChangeSetUnLocked(val executionId: String, val changeSet: ChangeSet, val status: ExecutionStatus)
@@ -39,6 +41,14 @@ class TestPersistEngine : PersistEngine(PersistConfig()) {
         }
         return changeSetUnLocked.first { it.executionId == changeSetId }.status
     }
+
+    override fun findExecutions(
+        page: PageRequest,
+        filterStatus: Set<ExecutionStatus>,
+        filterChangeSetId: String?
+    ): List<ExecutionReport> = emptyList()
+
+    override fun executionCount(): Int = changeSetTested.size
 
     override fun lock(executionId: String, changeSet: ChangeSet) {
         changeSetLocked.add(changeSet)

--- a/persist-mongodb/src/main/kotlin/io/saagie/updatarium/persist/model/MongoDbChangeSet.kt
+++ b/persist-mongodb/src/main/kotlin/io/saagie/updatarium/persist/model/MongoDbChangeSet.kt
@@ -18,10 +18,12 @@
 package io.saagie.updatarium.persist.model
 
 import io.saagie.updatarium.model.ChangeSet
+import io.saagie.updatarium.model.ExecutionReport
 import io.saagie.updatarium.model.ExecutionStatus
 import java.time.Instant
 
 data class MongoDbChangeSet(
+    val _id: String? = null,
     val changeSetId: String,
     val author: String,
     val status: String,
@@ -29,7 +31,21 @@ data class MongoDbChangeSet(
     val statusDate: Instant? = null,
     val force: Boolean = false,
     val log: List<String>
-)
+) {
+    fun toExecutionState() : ExecutionReport {
+        require(_id != null) {
+            "Id can't be null to be convert into execution state"
+        }
+        return ExecutionReport(
+            executionId = _id,
+            changeSetId = changeSetId,
+            author = author,
+            status = ExecutionStatus.valueOf(status),
+            forced = force,
+            statusDate = statusDate ?: lockDate
+        )
+    }
+}
 
 fun ChangeSet.toMongoDbDocument(executionId: String): MongoDbChangeSet = MongoDbChangeSet(
     changeSetId = executionId,

--- a/updatarium-admin-cli/Dockerfile
+++ b/updatarium-admin-cli/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:11
+
+ADD *.tar /
+RUN ln -s /updatarium-admin-cli*/ /updatarium-admin-cli
+
+WORKDIR /updatarium-admin-cli
+
+ENTRYPOINT ["/updatarium-admin-cli/bin/updatarium-admin-cli"]
+CMD ["--help"]

--- a/updatarium-admin-cli/build.gradle.kts
+++ b/updatarium-admin-cli/build.gradle.kts
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2019-2020 Pierre Leresteux.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+    kotlin("jvm")
+    application
+}
+config {
+    bintray { enabled = false }
+    publishing { enabled = false }
+}
+
+application {
+    mainClassName = "io.saagie.updatarium.admincli.StandaloneKt"
+}
+
+dependencies {
+    implementation(kotlin("stdlib-jdk8"))
+    implementation("com.github.ajalt:clikt:2.4.0")
+    // Updatarium deps
+    implementation(project(":core"))
+    implementation(project(":persist-mongodb"))
+    implementation(project(":engine-bash"))
+    implementation(project(":engine-mongodb"))
+    implementation(project(":engine-kubernetes"))
+    implementation(project(":engine-httpclient"))
+    // Logs
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.13.0")
+    implementation("org.apache.logging.log4j:log4j-core:2.13.0")
+}

--- a/updatarium-admin-cli/settings.gradle
+++ b/updatarium-admin-cli/settings.gradle
@@ -15,20 +15,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-rootProject.name = "updatarium"
-include(":core")
-include(":persist-mongodb")
-include(":engine-bash")
-include(":engine-mongodb")
-include(":engine-kubernetes")
-include(":engine-httpclient")
-include(":samples:basic")
-include(":samples:basic-mongodbpersist")
-include(":samples:basic-multiplechangelog")
-include(":samples:basic-multiplechangelog-withtag")
-include(":samples:http")
-include(":samples:bash")
-include(":samples:mongodb")
-include(":samples:kubernetes")
-include(":updatarium-cli")
-include(":updatarium-admin-cli")
+rootProject.name = 'updatarium-admin-cli'
+

--- a/updatarium-admin-cli/src/main/kotlin/io/saagie/updatarium/admincli/DisplayableTable.kt
+++ b/updatarium-admin-cli/src/main/kotlin/io/saagie/updatarium/admincli/DisplayableTable.kt
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2019-2020 Pierre Leresteux.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.saagie.updatarium.admincli
+
+class DisplayableTable(private val headers: List<String>, private val rows: List<List<String>>) {
+
+    private val columnSizes = getColumnSizes(headers, rows)
+
+    private fun printHeader() {
+        val rowFormat = columnSizes.indices
+            .joinToString(FIELD_SEPARATOR) { "%${columnSizes[it]}s" }
+        println(
+            rowFormat.format(completeWithString(headers, columnSizes.size)
+                .map { it.toUpperCase() }
+                .toTypedArray()
+            )
+        )
+    }
+
+    private fun printRows() {
+        val rowFormat = columnSizes.indices
+            .joinToString(FIELD_SEPARATOR) { "%${columnSizes[it]}s" }
+        rows.forEach {
+            println(rowFormat.format(completeWithString(it, columnSizes.size).toTypedArray()))
+        }
+    }
+
+    fun print() {
+        printHeader()
+        printRows()
+    }
+
+    companion object {
+
+        private const val FIELD_SEPARATOR = "\t"
+
+        private fun completeWithString(values: List<String>, expectedSize: Int): List<String> {
+            return if (expectedSize - values.size > 0)
+                completeWithString(values.plus(""), expectedSize - 1)
+                else values
+        }
+
+        private fun getColumnSizes(headers: List<String>, rows: List<List<String>>): List<Int> {
+            val headerSizes = headers.map { it.length }
+            val rowsSizes = rows.map { it.map { it.length } }
+            val concatenatedSizes = rowsSizes.plus(listOf(headerSizes))
+            val columnNb = concatenatedSizes.map { it.size }.max() ?: 0
+            return (0 until columnNb).map { index ->
+                concatenatedSizes.map { it.getOrElse(index) { 0 } }.max() ?: 0
+            }
+        }
+
+    }
+}

--- a/updatarium-admin-cli/src/main/kotlin/io/saagie/updatarium/admincli/ListCommand.kt
+++ b/updatarium-admin-cli/src/main/kotlin/io/saagie/updatarium/admincli/ListCommand.kt
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2019-2020 Pierre Leresteux.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.saagie.updatarium.admincli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.multiple
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.unique
+import com.github.ajalt.clikt.parameters.types.choice
+import com.github.ajalt.clikt.parameters.types.int
+import com.github.ajalt.clikt.parameters.types.restrictTo
+import io.saagie.updatarium.model.ExecutionStatus
+import io.saagie.updatarium.persist.MongodbPersistEngine
+import io.saagie.updatarium.persist.model.PageRequest
+import io.saagie.updatarium.persist.model.Sort
+
+class ListCommand : CliktCommand(help = "List the changeSet executions", name = "list") {
+
+    companion object {
+        const val DEFAULT_LIMIT_VALUE = 10
+        val EXECUTION_REPORT_RANGE_LIMIT = 0 .. 1000
+        val HEADERS = listOf(
+            "execution id",
+            "change set",
+            "status",
+            "forced?",
+            "author",
+            "record at"
+        )
+    }
+
+    private val limit by option(
+        "--limit",
+        help = "limit the changeSet display count " +
+                "(default 10, min ${EXECUTION_REPORT_RANGE_LIMIT.first}, max ${EXECUTION_REPORT_RANGE_LIMIT.last})"
+    )
+        .int()
+        .restrictTo(min = EXECUTION_REPORT_RANGE_LIMIT.first, max = EXECUTION_REPORT_RANGE_LIMIT.last)
+        .default(DEFAULT_LIMIT_VALUE)
+
+    private val skip by option(
+        "--skip",
+        help = "skip some changeSets (default 0, min 0)"
+    )
+        .int()
+        .restrictTo(min = 0)
+        .default(0)
+
+    private val filteredChangeSet by option(
+        "--change-set-id",  "-c",
+        help = "filter with one specific change set"
+    )
+
+    private val withStatus by option(
+        "--with-status", "-s",
+        help = "filter executions with specific status"
+    )
+        .choice(ExecutionStatus.values().map { it.name to it }.toMap())
+        .multiple()
+        .unique()
+
+    private val withError by option(
+        "--with-error", "-e",
+        help = "filter failed execution"
+    ).flag()
+
+    override fun run() {
+        val requestedStatus = if (withError) withStatus.plus(ExecutionStatus.FAIL) else withStatus
+        val statusToDisplay = if (requestedStatus.isEmpty()) ExecutionStatus.values().toSet() else requestedStatus
+
+        val rows = MongodbPersistEngine().findExecutions(
+            page = PageRequest(
+                size = limit,
+                skip = skip,
+                order = Sort.DESC
+            ),
+            filterStatus = statusToDisplay,
+            filterChangeSetId = filteredChangeSet
+
+        )
+            .sortedBy { it.statusDate }
+            .map {
+                listOf(
+                    it.executionId,
+                    it.changeSetId,
+                    it.status.name,
+                    if (it.forced) "FORCED" else "",
+                    it.author,
+                    it.statusDate.toString()
+                )
+            }
+        DisplayableTable(HEADERS, rows).print()
+    }
+}

--- a/updatarium-admin-cli/src/main/kotlin/io/saagie/updatarium/admincli/Standalone.kt
+++ b/updatarium-admin-cli/src/main/kotlin/io/saagie/updatarium/admincli/Standalone.kt
@@ -15,20 +15,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-rootProject.name = "updatarium"
-include(":core")
-include(":persist-mongodb")
-include(":engine-bash")
-include(":engine-mongodb")
-include(":engine-kubernetes")
-include(":engine-httpclient")
-include(":samples:basic")
-include(":samples:basic-mongodbpersist")
-include(":samples:basic-multiplechangelog")
-include(":samples:basic-multiplechangelog-withtag")
-include(":samples:http")
-include(":samples:bash")
-include(":samples:mongodb")
-include(":samples:kubernetes")
-include(":updatarium-cli")
-include(":updatarium-admin-cli")
+package io.saagie.updatarium.admincli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.subcommands
+
+
+class Standalone : CliktCommand(name = "updatarium-admin-cli", printHelpOnEmptyArgs = true) {
+    override fun run() {}
+}
+
+
+fun main(args: Array<String>) = Standalone()
+    .subcommands(
+        ListCommand()
+    )
+    .main(args)

--- a/updatarium-admin-cli/src/main/resources/log4j2.xml
+++ b/updatarium-admin-cli/src/main/resources/log4j2.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    SPDX-License-Identifier: Apache-2.0
+
+    Copyright 2019-2020 Pierre Leresteux.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<Configuration name="LogConfig" status="error">
+    <Appenders>
+        <Console name="STDOUT">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%-5p] %c{1}:%-3L - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+        <Logger name="org.mongodb" level="warn">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Add the persist engine admin cli.
Implements the find all changesets execution.
Add 2 methods to persist engine.

### Cli Commands

**./updatarium-admin-cli --help**
```
Usage: standalone [OPTIONS] COMMAND [ARGS]...

Options:
  -h, --help  Show this message and exit

Commands:
  list  List the changeSet executions
```


**./updatarium-admin-cli list --help**
```
Usage: updatarium-admin-cli list [OPTIONS]

  List the changeSet executions

Options:
  --limit INT                      limit the changeSet display count (default
                                   10, min 0, max 1000)
  --skip INT                       skip some changeSets (default 0, min 0)
  -c, --change-set-id TEXT         filter with one specific change set
  -s, --with-status [NOT_EXECUTED|EXECUTE|OK|FAIL]
                                   filter executions with specific status
  -e, --with-error                 filter failed execution
```